### PR TITLE
Add Qodly_OrgTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To see how to install the component in the Studio: [Qodly documentation](https:/
 - [qodly_chart](https://github.com/metayoub/qodly_chart) - Pie & Doughnut, Line and Area charts component. [Download here](https://github.com/metayoub/qodly_chart/releases)
 - [qodly_map](https://github.com/rihab-ze/qodly_map) - Map Component for Qodly studio using leaftletJs and OpenStreetMAp. [Download here](https://github.com/rihab-ze/qodly_map/releases)
 - [qodly_mediaPlayer](https://github.com/b-fadwa/audio-player) - The pack provides two components, a custom audio player and a custom video player. [Download here](https://github.com/b-fadwa/audio-player/releases)
+- [qodly_OrgTree](https://github.com/LimpalaerCyril/Qodly_OrgTree)) - Organizational tree component for Qodly. [Download here](https://github.com/LimpalaerCyril/Qodly_OrgTree/releases)
 - [qodly_Tags](https://github.com/metayoub/qodly_tags) - Tags component for Qodly studio. [Download here](https://github.com/metayoub/qodly_tags/releases)
 - [qodly_timeline](https://github.com/AyaBengherifa/Qodly_timeline) - Timeline component for Qodly studio. [Download here](https://github.com/AyaBengherifa/Qodly_timeline/releases)
 - [qodly_signature](https://github.com/metayoub/qodly_signature) - Signature component for Qodly studio. [Download here](https://github.com/metayoub/qodly_signature/releases)


### PR DESCRIPTION
Adding the custom component Qodly_OrgTree, which is using [react-organizational-chart](https://apexcharts.com/) to provide an organizational tree feature. This component adds an organizational tree, which can display a complete hierarchy of a company.

All component styling is customizable and easy to handle.
For ease of use, there are 2 predefined tree styles “default” and “full” available with just one click.